### PR TITLE
Update bitnami repository to point to full index

### DIFF
--- a/helm/featurehub/Chart.yaml
+++ b/helm/featurehub/Chart.yaml
@@ -8,7 +8,7 @@ appVersion: "1.5.8"
 dependencies:
   - name: postgresql
     version: 11.0.5
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: nats
     version: 0.13.1


### PR DESCRIPTION
Bitnami truncates their helm index every 6 months. see https://github.com/bitnami/charts/issues/10833

This change prevents the chart from breaking when the dependency gets truncated