### PR TITLE
Release 4.0.2 of the Helm Charts

### DIFF
--- a/helm/featurehub/Chart.yaml
+++ b/helm/featurehub/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: featurehub
 description: FeatureHub Release
 type: application
-version: 4.0.0
+version: 4.0.2
 icon: https://raw.githubusercontent.com/featurehub-io/featurehub/main/docs/modules/ROOT/images/fh_icon.png
-appVersion: "1.6.0"
+appVersion: "1.6.1"
 dependencies:
   - name: postgresql
     version: 12.1.13

--- a/helm/featurehub/README.md
+++ b/helm/featurehub/README.md
@@ -1,6 +1,6 @@
 # featurehub
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 FeatureHub Release
 
@@ -25,7 +25,7 @@ FeatureHub Release
 | dacha.extraVolumeMounts | list | `[]` | List of extra mounts to add to Dacha Deployment |
 | dacha.extraVolumes | list | `[]` | List of extra volumes to add to Dacha Deployment |
 | dacha.image.repository | string | `"featurehub/dacha2"` |  |
-| dacha.image.tag | string | `"1.6.0"` |  |
+| dacha.image.tag | string | `"1.6.1-RC"` |  |
 | dacha.imagePullSecrets | list | `[]` |  |
 | dacha.ingress.annotations | object | `{}` |  |
 | dacha.ingress.className | string | `""` |  |
@@ -54,13 +54,13 @@ FeatureHub Release
 | edge.enabled | bool | `true` |  |
 | edge.envAsAppConfigFile | bool | `true` | If `true`, entries from `environmentVars` and `envFromSecret` fields will be mapped to configuration files. `environmentVars` to /etc/app-config/application.properties `envFromSecret` to /etc/app-config/secrets.properties Used for retrocompatiblity with FeatureHub controller versions lower than 1.5.0 https://docs.featurehub.io/featurehub/latest/installation.html#_run_configuration |
 | edge.envFromSecret | string | `""` | Name of the secret containing secret properties, to be exposed as environment variables to edge deployment. Create the secret in advance, then reference it here. As of 1.5.0 all FeatureHub controller properties are available as environment variables using the same case Entries of the secret specified here are the same as would be specified in /etc/app-config/secrets.properties |
-| edge.environmentVars | object | `{"dacha.url.default":"http://featurehub-dacha:8600","dacha1.enabled":"false","dacha2.enabled":"true","listen.pool-size":"30","maxSlots":"30","server.gracePeriodInSeconds":"10","update.pool-size":"30"}` | Environment variables to be exposed to edge deployment. As of 1.5.0 all FeatureHub controller properties are available as environment variables using the same case. Entries accepted here are the same as would be specified in /etc/app-config/applications.properties. Note that `server.port` and `monitor.port` use their default values of `8085` and `8701` respectively, to make it easier to implement the deployment, service and the prometheus serviceMonitor manifests. |
+| edge.environmentVars | object | `{"dacha.timeout.read":"12000","dacha.url.default":"http://featurehub-dacha:8600","dacha1.enabled":"false","dacha2.enabled":"true","listen.pool-size":"30","maxSlots":"30","server.gracePeriodInSeconds":"10","update.pool-size":"30"}` | Environment variables to be exposed to edge deployment. As of 1.5.0 all FeatureHub controller properties are available as environment variables using the same case. Entries accepted here are the same as would be specified in /etc/app-config/applications.properties. Note that `server.port` and `monitor.port` use their default values of `8085` and `8701` respectively, to make it easier to implement the deployment, service and the prometheus serviceMonitor manifests. |
 | edge.extraContainers | list | `[]` | List of extra containers to add to Edge Pod |
 | edge.extraEnvironmentVars | object | `{}` | Extra environment variables to be exposed to edge deployment. In terms of environment variable setting, this is the same as `environmentVars` field. The only difference is that if `envAsAppConfigFile: true`, only entries from `environmentVars` will be mapped to the application.properties configuration file, and not the ones from `extraEnvironmentVars`. |
 | edge.extraVolumeMounts | list | `[]` | List of extra mounts to add to Edge Deployment |
 | edge.extraVolumes | list | `[]` | List of extra volumes to add to Edge Deployment |
 | edge.image.repository | string | `"featurehub/edge"` |  |
-| edge.image.tag | string | `"1.6.0"` |  |
+| edge.image.tag | string | `"1.6.1-RC"` |  |
 | edge.imagePullSecrets | list | `[]` |  |
 | edge.ingress.annotations | object | `{}` |  |
 | edge.ingress.className | string | `""` |  |
@@ -108,7 +108,7 @@ FeatureHub Release
 | managementRepository.extraVolumeMounts | list | `[]` | List of extra mounts to add to Management Repository Deployment |
 | managementRepository.extraVolumes | list | `[]` | List of extra volumes to add to Management Repository Deployment |
 | managementRepository.image.repository | string | `"featurehub/mr"` |  |
-| managementRepository.image.tag | string | `"1.6.0"` |  |
+| managementRepository.image.tag | string | `"1.6.1-RC"` |  |
 | managementRepository.imagePullSecrets | list | `[]` |  |
 | managementRepository.ingress.annotations | object | `{}` |  |
 | managementRepository.ingress.className | string | `""` |  |

--- a/helm/featurehub/templates/dacha/deployment.yaml
+++ b/helm/featurehub/templates/dacha/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           livenessProbe:
             initialDelaySeconds: 20
             periodSeconds: 20
-            failureThreshold: 2
+            failureThreshold: 1  # we set this to 1 because if the health check fails, it means the cache is compromised
             timeoutSeconds: 3
             httpGet:
               path: /health/liveness
@@ -88,7 +88,7 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 20
             successThreshold: 2
-            failureThreshold: 2
+            failureThreshold: 1
             timeoutSeconds: 3
             httpGet:
               path: /health/readiness
@@ -96,7 +96,7 @@ spec:
           volumeMounts:
           {{- if gt ( len .Values.global.extraCommonConfigFiles ) 0 -}}
           {{- range $cm := .Values.global.extraCommonConfigFiles }}
-            - name: {{ $cm.configMapSuffix }} 
+            - name: {{ $cm.configMapSuffix }}
               mountPath: "/etc/common-config/{{ $cm.fileName }}"
               subPath: {{ $cm.fileName | quote }}
           {{- end }}

--- a/helm/featurehub/templates/global-ingress.yaml
+++ b/helm/featurehub/templates/global-ingress.yaml
@@ -3,17 +3,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: featurehub
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- with .Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  defaultBackend:
-    service:
-      name: "featurehub-management-repository"
-      port:
-        name: http
   rules:
     - http:
         paths:
@@ -22,6 +18,13 @@ spec:
             backend:
               service:
                 name: "featurehub-edge"
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "featurehub-management-repository"
                 port:
                   name: http
   {{- end }}

--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -102,7 +102,7 @@ managementRepository:
 
   image:
     repository: featurehub/mr
-    tag: 1.6.0
+    tag: 1.6.1-RC
 
   pullPolicy: IfNotPresent
 
@@ -267,7 +267,7 @@ edge:
 
   image:
     repository: featurehub/edge
-    tag: 1.6.0
+    tag: 1.6.1-RC
 
   pullPolicy: IfNotPresent
 
@@ -311,6 +311,7 @@ edge:
     dacha.url.default: http://featurehub-dacha:8600
     dacha1.enabled: "false"
     dacha2.enabled: "true"
+    dacha.timeout.read: "12000"  # this should reflect the sizing/capability of your database to respond to the 1st time a key is requested
 
 
   # -- If `true`, entries from `environmentVars` and `envFromSecret` fields will be mapped to configuration files.
@@ -405,7 +406,7 @@ dacha:
 
   image:
     repository: featurehub/dacha2
-    tag: 1.6.0
+    tag: 1.6.1-RC
 
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Dacha2 should have a timeout associated
with how fast/slow the database is
for new requests.