### PR TITLE
Upgrade NATS, Support ArgoCD

### DIFF
--- a/helm/featurehub/Chart.lock
+++ b/helm/featurehub/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.1.13
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
-  version: 0.19.6
-digest: sha256:0043774333081bf7b7d2d02e1b2b67dc47e5952cfec9ccca6fbd3c5f6628bf81
-generated: "2023-02-02T16:29:07.370334+13:00"
+  version: 1.1.5
+digest: sha256:d7b5fc428158252438bc3131fc272bee5cd68e9ecf370a6da6ddd82e31d8a17a
+generated: "2023-12-08T18:11:13.778337+13:00"

--- a/helm/featurehub/Chart.yaml
+++ b/helm/featurehub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: featurehub
 description: FeatureHub Release
 type: application
-version: 4.0.8
+version: 4.0.9
 icon: https://raw.githubusercontent.com/featurehub-io/featurehub/main/docs/modules/ROOT/images/fh_icon.png
 appVersion: "1.7.0"
 maintainers:
@@ -14,6 +14,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: nats
-    version: 0.19.6
+    version: 1.1.5
     repository: https://nats-io.github.io/k8s/helm/charts/
     condition: nats.enabled

--- a/helm/featurehub/README.md
+++ b/helm/featurehub/README.md
@@ -1,6 +1,6 @@
 # featurehub
 
-![Version: 4.0.8](https://img.shields.io/badge/Version-4.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 4.0.9](https://img.shields.io/badge/Version-4.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 FeatureHub Release
 
@@ -14,7 +14,7 @@ FeatureHub Release
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://nats-io.github.io/k8s/helm/charts/ | nats | 0.19.6 |
+| https://nats-io.github.io/k8s/helm/charts/ | nats | 1.1.5 |
 | https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami | postgresql | 12.1.13 |
 
 ## Values
@@ -53,6 +53,7 @@ FeatureHub Release
 | dacha.securityContext.runAsUser | int | `999` |  |
 | dacha.serviceAccount.annotations | object | `{}` |  |
 | dacha.serviceAccount.create | bool | `true` |  |
+| dacha.serviceAccount.labels | object | `{}` |  |
 | dacha.serviceAccount.name | string | `""` |  |
 | dacha.strategy | object | `{}` |  |
 | dacha.tolerations | list | `[]` |  |
@@ -88,6 +89,7 @@ FeatureHub Release
 | edge.securityContext.runAsUser | int | `999` |  |
 | edge.serviceAccount.annotations | object | `{}` |  |
 | edge.serviceAccount.create | bool | `true` |  |
+| edge.serviceAccount.labels | object | `{}` |  |
 | edge.serviceAccount.name | string | `""` |  |
 | edge.strategy | object | `{}` |  |
 | edge.tolerations | list | `[]` |  |
@@ -138,6 +140,7 @@ FeatureHub Release
 | managementRepository.securityContext.runAsUser | int | `999` |  |
 | managementRepository.serviceAccount.annotations | object | `{}` |  |
 | managementRepository.serviceAccount.create | bool | `true` |  |
+| managementRepository.serviceAccount.labels | object | `{}` |  |
 | managementRepository.serviceAccount.name | string | `""` |  |
 | managementRepository.strategy | object | `{}` |  |
 | managementRepository.tolerations | list | `[]` |  |

--- a/helm/featurehub/templates/common/configmap-global-common-config-extra.yaml
+++ b/helm/featurehub/templates/common/configmap-global-common-config-extra.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-global-extra-{{ $cm.configMapSuffix }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/common/configmap-global-common-config.yaml
+++ b/helm/featurehub/templates/common/configmap-global-common-config.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-global-common-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/common/configmap-global-common-env.yaml
+++ b/helm/featurehub/templates/common/configmap-global-common-env.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-global-common-env
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/dacha/configmap-app-config.yaml
+++ b/helm/featurehub/templates/dacha/configmap-app-config.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-dacha-app-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/dacha/configmap-env.yaml
+++ b/helm/featurehub/templates/dacha/configmap-env.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-dacha-env
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/dacha/deployment.yaml
+++ b/helm/featurehub/templates/dacha/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "featurehub.dacha.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/dacha/ingress.yaml
+++ b/helm/featurehub/templates/dacha/ingress.yaml
@@ -18,8 +18,9 @@ metadata:
   name: {{ include "featurehub.dacha.name" . }}
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
-  {{- with .Values.dacha.ingress.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "25"
+  {{- with .Values.dacha.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm/featurehub/templates/dacha/pdb.yaml
+++ b/helm/featurehub/templates/dacha/pdb.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ .Capabilities.APIVersions.Has "policy/v1" | ternary "policy/v1" "
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "featurehub.dacha.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/dacha/service.yaml
+++ b/helm/featurehub/templates/dacha/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "featurehub.dacha.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
 spec:
@@ -17,7 +19,7 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
-  {{- end }}  
+  {{- end }}
   selector:
     {{- include "featurehub.dacha.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/featurehub/templates/dacha/serviceaccount.yaml
+++ b/helm/featurehub/templates/dacha/serviceaccount.yaml
@@ -4,9 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "featurehub.dacha.serviceAccountName" . }}
-  labels:
-  {{- with .Values.dacha.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  {{- with .Values.dacha.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.dacha.serviceAccount.labels }}
+  labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm/featurehub/templates/dacha/servicemonitor.yaml
+++ b/helm/featurehub/templates/dacha/servicemonitor.yaml
@@ -4,6 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "featurehub.dacha.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
   labels:
     {{- include "featurehub.dacha.labels" . | nindent 4 }}
     {{- with .Values.dacha.prometheus.labels }}

--- a/helm/featurehub/templates/edge/configmap-app-config.yaml
+++ b/helm/featurehub/templates/edge/configmap-app-config.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-edge-app-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/edge/configmap-env.yaml
+++ b/helm/featurehub/templates/edge/configmap-env.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-edge-env
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/edge/deployment.yaml
+++ b/helm/featurehub/templates/edge/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "featurehub.edge.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/edge/ingress.yaml
+++ b/helm/featurehub/templates/edge/ingress.yaml
@@ -20,6 +20,7 @@ metadata:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
   {{- with .Values.edge.ingress.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "25"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm/featurehub/templates/edge/pdb.yaml
+++ b/helm/featurehub/templates/edge/pdb.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ .Capabilities.APIVersions.Has "policy/v1" | ternary "policy/v1" "
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "featurehub.edge.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/edge/service.yaml
+++ b/helm/featurehub/templates/edge/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "featurehub.edge.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
 spec:
@@ -17,7 +19,7 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
-  {{- end }}  
+  {{- end }}
   selector:
     {{- include "featurehub.edge.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/featurehub/templates/edge/serviceaccount.yaml
+++ b/helm/featurehub/templates/edge/serviceaccount.yaml
@@ -4,9 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "featurehub.edge.serviceAccountName" . }}
-  labels:
-  {{- with .Values.edge.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  {{- with .Values.edge.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.edge.serviceAccount.labels }}
+  labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm/featurehub/templates/edge/servicemonitor.yaml
+++ b/helm/featurehub/templates/edge/servicemonitor.yaml
@@ -4,6 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "featurehub.edge.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
   labels:
     {{- include "featurehub.edge.labels" . | nindent 4 }}
     {{- with .Values.edge.prometheus.labels }}

--- a/helm/featurehub/templates/global-ingress.yaml
+++ b/helm/featurehub/templates/global-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
   {{- with .Values.global.ingress.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "20"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm/featurehub/templates/management-repository/configmap-app-config.yaml
+++ b/helm/featurehub/templates/management-repository/configmap-app-config.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-management-repository-app-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/management-repository/configmap-env.yaml
+++ b/helm/featurehub/templates/management-repository/configmap-env.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "featurehub.fullname" . }}-management-repository-env
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 data:

--- a/helm/featurehub/templates/management-repository/deployment.yaml
+++ b/helm/featurehub/templates/management-repository/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "featurehub.managementRepository.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/management-repository/ingress.yaml
+++ b/helm/featurehub/templates/management-repository/ingress.yaml
@@ -20,6 +20,7 @@ metadata:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
   {{- with .Values.managementRepository.ingress.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "25"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm/featurehub/templates/management-repository/pdb.yaml
+++ b/helm/featurehub/templates/management-repository/pdb.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ .Capabilities.APIVersions.Has "policy/v1" | ternary "policy/v1" "
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "featurehub.managementRepository.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "22"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/management-repository/service.yaml
+++ b/helm/featurehub/templates/management-repository/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "featurehub.managementRepository.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
 spec:

--- a/helm/featurehub/templates/management-repository/serviceaccount.yaml
+++ b/helm/featurehub/templates/management-repository/serviceaccount.yaml
@@ -4,9 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "featurehub.managementRepository.serviceAccountName" . }}
-  labels:
-  {{- with .Values.managementRepository.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  {{- with .Values.managementRepository.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.managementRepository.serviceAccount.annotations }}
+  labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm/featurehub/templates/management-repository/servicemonitor.yaml
+++ b/helm/featurehub/templates/management-repository/servicemonitor.yaml
@@ -4,6 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "featurehub.managementRepository.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
   labels:
     {{- include "featurehub.managementRepository.labels" . | nindent 4 }}
     {{- with .Values.managementRepository.prometheus.labels }}

--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -129,6 +129,8 @@ managementRepository:
     create: true
     # Annotations to add to the service account
     annotations: {}
+    # Labels to add to the service account
+    labels: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
@@ -294,6 +296,8 @@ edge:
     create: true
     # Annotations to add to the service account
     annotations: {}
+    # Labels to add to the service account
+    labels: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
@@ -433,6 +437,8 @@ dacha:
     create: true
     # Annotations to add to the service account
     annotations: {}
+    # Labels to add to the service account
+    labels: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
@@ -547,9 +553,6 @@ nats:
     name: featurehub
     replicas: 3
   topologyKeys: []
-    # - "kubernetes.io/hostname"
-    # - "topology.kubernetes.io/zone"
-    # - "topology.kubernetes.io/region"
 
 # ------------------------------------------------------------------------------- #
 # PostgreSQL Helm Chart from Bitnami:


### PR DESCRIPTION
This change updates the chart to use the latest
NATS release as at time of update (1.1.5) and
adds the requisite annotations for rolling out on
ArgoCD.