### PR TITLE
Fix for podAnnotations

### DIFF
--- a/helm/featurehub/Chart.yaml
+++ b/helm/featurehub/Chart.yaml
@@ -8,11 +8,11 @@ description: "FeatueHub is an Enterprise Grade, Cloud Native Feature Management 
   NATS or Google PubSub as a streaming layer. Kinesis is available but has limited testing. Documentation on configuration is provided on [Featurehub Docs](https://docs.featurehub.io/featurehub/latest/configuration.html)
 
 
-  NATS and Postgres are *NOT* requirements of the project and are included only for evaluation convenience and evaluation. It is expected people will install
+  NATS and Postgres are *NOT* requirements of the project and are included only for convenience and evaluation. It is expected people will install
   their own requirements.
   "
 type: application
-version: 4.1.0
+version: 4.1.1
 icon: https://raw.githubusercontent.com/featurehub-io/featurehub/main/docs/modules/ROOT/images/fh_icon.png
 appVersion: "1.7.0"
 maintainers:

--- a/helm/featurehub/README.md
+++ b/helm/featurehub/README.md
@@ -1,12 +1,12 @@
 # featurehub
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 FeatueHub is an Enterprise Grade, Cloud Native Feature Management platform that is available to suite any organisations requirements. This fully supported Helm chart is the Open Source version of the product, which has all the same features as the [SaaS product](https://app.featurehub.io).
 
 The project is hosted on [Github](https://github.com/featurehub-io/featurehub). It supports Postgres, MySQL, MariaDB or Oracle Database deployments, and uses NATS or Google PubSub as a streaming layer. Kinesis is available but has limited testing. Documentation on configuration is provided on [Featurehub Docs](https://docs.featurehub.io/featurehub/latest/configuration.html)
 
-NATS and Postgres are *NOT* requirements of the project and are included only for evaluation convenience and evaluation. It is expected people will install their own requirements.
+NATS and Postgres are *NOT* requirements of the project and are included only for convenience and evaluation. It is expected people will install their own requirements.
 
 ## Maintainers
 
@@ -172,6 +172,7 @@ NATS and Postgres are *NOT* requirements of the project and are included only fo
 | managementRepository.tolerations | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nats | object | `{"cluster":{"enabled":true,"name":"featurehub","replicas":3},"enabled":true,"topologyKeys":[]}` | ----------------------------------------------------------------------------- # |
+| podAnnotations | object | `{}` |  |
 | postgresql | object | `{"enabled":true,"global":{"postgresql":{"auth":{"postgresPassword":"postgresql"}}},"primary":{"initdb":{"scripts":{"featurehub.sql":"CREATE USER featurehub PASSWORD 'featurehub' LOGIN;\nCREATE DATABASE featurehub;\nGRANT ALL PRIVILEGES ON DATABASE featurehub TO featurehub;\n\\connect featurehub\nGRANT ALL ON SCHEMA public TO featurehub;"}},"persistence":{"accessModes":["ReadWriteOnce"],"enabled":true,"size":"128Mi","storageClassName":"standard"}}}` | ----------------------------------------------------------------------------- # |
 
 ----------------------------------------------

--- a/helm/featurehub/templates/dacha/deployment.yaml
+++ b/helm/featurehub/templates/dacha/deployment.yaml
@@ -38,7 +38,10 @@ spec:
         {{- end }}
 
         {{- range $key, $value := .Values.dacha.podAnnotations }}
-        {{ $key }}: {{ $value}}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key | quote }}: {{ $value | quote }}
         {{- end }}
       labels:
         {{- include "featurehub.dacha.selectorLabels" . | nindent 8 }}

--- a/helm/featurehub/templates/edge/deployment.yaml
+++ b/helm/featurehub/templates/edge/deployment.yaml
@@ -37,8 +37,11 @@ spec:
         checksum/global-common-config-extra: {{ include (print $.Template.BasePath "/common/configmap-global-common-config-extra.yaml") . | sha256sum }}
         {{- end }}
 
+        {{- range $key, $value := .Values.edge.podAnnotations }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value}}
+        {{ $key | quote }}: {{ $value | quote }}
         {{- end }}
       labels:
         {{- include "featurehub.edge.selectorLabels" . | nindent 8 }}

--- a/helm/featurehub/templates/management-repository/deployment.yaml
+++ b/helm/featurehub/templates/management-repository/deployment.yaml
@@ -37,8 +37,11 @@ spec:
         checksum/global-common-config-extra: {{ include (print $.Template.BasePath "/common/configmap-global-common-config-extra.yaml") . | sha256sum }}
         {{- end }}
 
+        {{- range $key, $value := .Values.managementRepository.podAnnotations }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value}}
+        {{ $key | quote }}: {{ $value | quote }}
         {{- end }}
       labels:
         {{- include "featurehub.managementRepository.selectorLabels" . | nindent 8 }}

--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -3,6 +3,8 @@
 
 nameOverride: ""
 fullnameOverride: ""
+podAnnotations: {}
+
 
 # global sections are normally reserved for cross application configuration, where multiple apps are in the repository,
 # we should generally not use this section


### PR DESCRIPTION
Pod Annotations need to be quoted in
case of special characters and need to
be consistently applied. Support is
added for global pod annotations and
deployment specific annotations.

Fixes #21