### PR TITLE
Fix pubsub-emulator chart error: wrong number of args for include

### DIFF
--- a/helm/pubsub-emulator/Chart.yaml
+++ b/helm/pubsub-emulator/Chart.yaml
@@ -4,5 +4,5 @@ description: "This is a helm chart for the pubsub emulator, which is useful for 
   so please do not raise issues against it. We do accept PRs however to improve it if you wish."
 
 type: application
-version: 1.0.0
-appVersion: "398.0.0"
+version: 1.0.1
+appVersion: "472.0.0"

--- a/helm/pubsub-emulator/templates/statefulset.yaml
+++ b/helm/pubsub-emulator/templates/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default include "pubsub-emular-app-version" . }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "pubsub-emular-app-version" .) }}"
           command:
           - gcloud
           - beta


### PR DESCRIPTION
Hello,

A fix for the error in pubsub-emulator chart:
`Error: template: pubsub-emulator/templates/statefulset.yaml:35:80: executing "pubsub-emulator/templates/statefulset.yaml" at <include>: wrong number of args for include: want 2 got 0`

How to reproduce:
`helm install pubsub featurehub/pubsub-emulator`

Also, updating the appVersion to the actual one.