### PR TITLE
add env support for managementRepository deployment

### DIFF
--- a/helm/featurehub/README.md
+++ b/helm/featurehub/README.md
@@ -153,6 +153,7 @@ NATS and Postgres are *NOT* requirements of the project and are included only fo
 | managementRepository.image.repository | string | `"featurehub/mr"` |  |
 | managementRepository.image.tag | string | `""` |  |
 | managementRepository.imagePullSecrets | list | `[]` |  |
+| managementRepository.env | list | `[]` | Additional environment variables for management repository |
 | managementRepository.ingress.annotations | object | `{}` |  |
 | managementRepository.ingress.className | string | `""` |  |
 | managementRepository.ingress.enabled | bool | `false` |  |

--- a/helm/featurehub/templates/management-repository/deployment.yaml
+++ b/helm/featurehub/templates/management-repository/deployment.yaml
@@ -88,6 +88,10 @@ spec:
                 name: {{ .Values.managementRepository.envFromSecret }}
             {{- end }}
           {{- end }}
+          {{- with .Values.managementRepository.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8085

--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -212,6 +212,17 @@ managementRepository:
   # Entries of the secret specified here are the same as would be specified in /etc/app-config/secrets.properties
   envFromSecret: ""
 
+  # -- List of environment variables to be exposed to management-repository deployment.
+  # This allows you to set individual environment variables with valueFrom references to secrets or configmaps.
+  # Example:
+  # env:
+  #   - name: db.password
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: postgres-secret
+  #         key: password
+  env: []
+
   # -- Prometheus configuration
   prometheus:
     # -- Whether to enable or disable prometheus metrics endpoints, and serviceMonitor


### PR DESCRIPTION
**Background:**
We are using CloudNativePG (CNPG) operator to manage PostgreSQL databases in our Kubernetes cluster. CNPG automatically generates secrets containing database connection credentials (URL, username, password, etc.) for applications to consume.

**Problem:**
The FeatureHub Helm chart's `managementRepository` deployment had no mechanism to inject environment variables from external sources like CNPG-generated secrets. The chart only supported hardcoded values or global environment variables, but didn't allow mapping specific secrets to the management repository component.

**Solution:**
This PR adds support for custom environment variables in the `managementRepository` deployment by:

1. **Adding `env` field to values.yaml** - Allows users to specify additional environment variables as a list
2. **Updating deployment template** - Adds conditional rendering of the `env` section when `managementRepository.env` is defined
3. **Documentation** - Updates README.md with the new configuration option

**Use Case:**
Now we can properly configure FeatureHub to use CNPG-generated PostgreSQL credentials:

```yaml
managementRepository:
      env:
        - name: db.url
          value: "jdbc:postgresql://featurehub-postgres-rw.infra.svc.cluster.local:5432/featurehub"
        - name: db.username
          valueFrom:
            secretKeyRef:
              name: featurehub-postgres-app
              key: username
        - name: db.password
          valueFrom:
            secretKeyRef:
              name: featurehub-postgres-app
              key: password
        - name: db.connections
          value: "20"
```

This enables the ability to map and use Kubernetes secrets for secure configuration management and seamless integration with external secret providers like CNPG.