### PR TITLE
fix NATS default values

### DIFF
--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -685,16 +685,14 @@ googlepubsub:
       topicName: "enriched-feature-data"
 
 # ------------------------------------------------------------------------------- #
-# NATS Helm Chart from Bitnami
+# Official NATS Helm Chart
 # Documentation: https://github.com/nats-io/k8s/tree/main/helm/charts/nats
 # ------------------------------------------------------------------------------- #
 nats:
   enabled: true
-  cluster:
-    enabled: true
-    name: featurehub
-    replicas: 3
-  topologyKeys: []
+  config:
+    cluster:
+      enabled: true
 
 # ------------------------------------------------------------------------------- #
 # PostgreSQL Helm Chart from Bitnami:


### PR DESCRIPTION
The default values in this chart do not match the values expected by the upstream NATS chart .

This is causing deployments with default values to provision a single NATS pod instead of the expected 3 replicas.

Upstream references:
- values.yaml
https://github.com/nats-io/k8s/blob/nats-1.1.5/helm/charts/nats/values.yaml#L50-L52
- StatefulSet Template
https://github.com/nats-io/k8s/blob/nats-1.1.5/helm/charts/nats/files/stateful-set/stateful-set.yaml#L12-L13

## Output of `helm template`

### Before

```
apiVersion: apps/v1
kind: StatefulSet
spec:
  replicas: 1
```

### After
```
apiVersion: apps/v1
kind: StatefulSet
spec:
  replicas: 3
```